### PR TITLE
Change app name

### DIFF
--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Lanseerpoort"</string>
     <string name="home" msgid="5921706419368316758">"Tuis"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Kernprogramme"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Tuis"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Kernprogramme"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Kies muurpapier uit"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Stel muurpapier"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Muurpapiere"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Vouer is gesluit"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Vouer hernoem na <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Vouer: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"አስነሺ"</string>
     <string name="home" msgid="5921706419368316758">"መነሻ"</string>
     <string name="uid_name" msgid="3371120195364560632">"የAndroid ኮር ትግበራዎች"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"መነሻ"</string>
     <string name="uid_name" msgid="3371120195364560632">"የAndroid ኮር ትግበራዎች"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"ልጣፍ ምረጥ ከ"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"ልጣፍ አዘጋጅ"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"ልጥፎች"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"አቃፊ ተዘግቷል"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"አቃፊ ዳግም ወደ <xliff:g id="NAME">%1$s</xliff:g> ተሰይሟል"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"አቃፊ ስም፦ <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"المشغل"</string>
     <string name="home" msgid="5921706419368316758">"المنزل"</string>
     <string name="uid_name" msgid="3371120195364560632">"تطبيقات Android المركزية"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"المنزل"</string>
     <string name="uid_name" msgid="3371120195364560632">"تطبيقات Android المركزية"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"اختيار خلفية من"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"تعيين خلفية"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"الخلفيات"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"تم إغلاق المجلد"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"تمت إعادة تسمية المجلد إلى <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"المجلد: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Панэль запуску"</string>
     <string name="home" msgid="5921706419368316758">"На галоўную старонку"</string>
     <string name="uid_name" msgid="3371120195364560632">"Асноўныя прыкладанні для Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"На галоўную старонку"</string>
     <string name="uid_name" msgid="3371120195364560632">"Асноўныя прыкладанні для Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Выбраць шпалеры"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Усталяваць шпалеры"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Шпалеры"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Тэчка закрыта"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Тэчка перайменавана ў <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Тэчка <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Стартов панел"</string>
     <string name="home" msgid="5921706419368316758">"Начало"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основни приложения на Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Начало"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основни приложения на Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Избор на тапет от"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Задаване на тапет"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Тапети"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Папката бе затворена"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Папката е преименувана на „<xliff:g id="NAME">%1$s</xliff:g>“"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Папка: „<xliff:g id="NAME">%1$s</xliff:g>“"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -19,7 +19,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Menú d\'aplicacions"</string>
+    <string name="application_name" msgid="8424725141379931883">Inici del Fairphone 1</string>
     <string name="home" msgid="5921706419368316758">"Inici"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicacions principals d\'Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -22,7 +22,6 @@
     <string name="application_name" msgid="8424725141379931883">Inici del Fairphone 1</string>
     <string name="home" msgid="5921706419368316758">"Inici"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicacions principals d\'Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Selecciona el fons de pantalla"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Estableix el fons de pantalla"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tria el fons de pantalla"</string>
@@ -107,10 +106,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Carpeta tancada"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"S\'ha canviat el nom de la carpeta a <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Carpeta: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
     
     <!-- Fairphone -->
     <!-- Your Apps -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Plocha"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Plocha"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Vybrat tapetu:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Nastavit tapetu"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tapety"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Složka je uzavřena"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Složka přejmenována na <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Složka: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Startside"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kerneprogrammer"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Startside"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kerneprogrammer"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Vælg baggrund fra"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Angiv tapet"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tapeter"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mappen er lukket"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mappen er omdøbt til <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mappe: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Startbildschirm"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android System-Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Hintergrund auswählen"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Hintergrund festlegen"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Hintergrund-Bilder"</string>
@@ -106,10 +105,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Ordner wurde geschlossen"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Ordner umbenannt in <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Ordner: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
     
     <!-- Fairphone -->
     <!-- Your Apps -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Fairphone OS"</string>
     <string name="home" msgid="5921706419368316758">"Startbildschirm"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android System-Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Αρχική σελίδα"</string>
     <string name="uid_name" msgid="3371120195364560632">"Βασικές εφαρμογές Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Αρχική σελίδα"</string>
     <string name="uid_name" msgid="3371120195364560632">"Βασικές εφαρμογές Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Επιλογή ταπετσαρίας από"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Ορισμός ταπετσαρίας"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Ταπετσαρίες"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Ο φάκελος έκλεισε"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Ο φάκελος μετονομάστηκε σε <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Φάκελος: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Fairphone Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Choose wallpaper from"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Set wallpaper"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Wallpaper"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Folder closed"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Folder renamed to <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folder: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Casa"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicaciones del núcleo de Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Elegir un fondo de pantalla de"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Definir como fondo de pantalla"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Papeles tapiz"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Se cerró la carpeta."</string>
     <string name="folder_renamed" msgid="7951233572858053642">"El nombre de la carpeta se cambió a <xliff:g id="NAME">%1$s</xliff:g>."</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Carpeta: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"FairLauncher"</string>
     <string name="home" msgid="5921706419368316758">"Casa"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicaciones del núcleo de Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -22,7 +22,6 @@
     <string name="application_name" msgid="8424725141379931883">Inicio del Fairphone 1</string>
     <string name="home" msgid="5921706419368316758">Inicio</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicaciones básicas de Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Seleccionar fondo de pantalla de"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Establecer fondo de pantalla"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Fondos de pantalla"</string>
@@ -107,10 +106,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Carpeta cerrada"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Se ha cambiado el nombre de la carpeta a <xliff:g id="NAME">%1$s</xliff:g>."</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Carpeta: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
     
     <!-- Fairphone -->
     <!-- Your Apps -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -19,8 +19,8 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Fairphone OS"</string>
-    <string name="home" msgid="5921706419368316758">"Casa"</string>
+    <string name="application_name" msgid="8424725141379931883">Inicio del Fairphone 1</string>
+    <string name="home" msgid="5921706419368316758">Inicio</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicaciones básicas de Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Seleccionar fondo de pantalla de"</string>
@@ -71,7 +71,7 @@
     <string name="menu_help" msgid="4901160661634590633">"Ayuda"</string>
     <string name="cab_menu_delete_app" msgid="4089398025537640349">"Desinstalar la aplicación"</string>
     <string name="cab_menu_app_info" msgid="914548323652698884">"Información de la aplicación"</string>
-    <string name="cab_app_selection_text" msgid="6378522164293415735">"1 aplicación seleccionada"</string>
+    <string name="cab_app_selection_text" msgid="6378522164293415735">Una aplicación seleccionada</string>
     <string name="cab_widget_selection_text" msgid="962527270506951955">"Se ha seleccionado un widget."</string>
     <string name="cab_folder_selection_text" msgid="8916111874189565067">"Se ha seleccionado una carpeta."</string>
     <string name="cab_shortcut_selection_text" msgid="8115847384500412878">"Se ha seleccionado un acceso directo."</string>
@@ -194,5 +194,4 @@
     <string name="google_apps_download_error">Error al descargar los archivos. Por favor, inténtelo de nuevo.</string>
     <string name="google_apps_connection_title">Wi-Fi desconectado</string>
     <string name="google_apps_connection_description">El archivo que está intentando descargar es muy grande para conexiones móviles (~100mb). Por favor, conéctese a un punto Wi-Fi e inténtelo de nuevo.</string>
-    
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Käivitaja"</string>
     <string name="home" msgid="5921706419368316758">"Kodu"</string>
     <string name="uid_name" msgid="3371120195364560632">"Androidi tuumrakendused"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Kodu"</string>
     <string name="uid_name" msgid="3371120195364560632">"Androidi tuumrakendused"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Taustapildi valimiskoht:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Määra taustapilt"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Taustapildid"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Kaust suletud"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Kausta uus nimi: <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"<xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"راه انداز"</string>
     <string name="home" msgid="5921706419368316758">"صفحهٔ اصلی"</string>
     <string name="uid_name" msgid="3371120195364560632">"برنامه‌های Android Core"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"صفحهٔ اصلی"</string>
     <string name="uid_name" msgid="3371120195364560632">"برنامه‌های Android Core"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"انتخاب تصویر زمینه از"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"تنظیم تصویر زمینه"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"تصاویر زمینه"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"پوشه بسته شد"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"نام پوشه به <xliff:g id="NAME">%1$s</xliff:g> تغییر کرد"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"پوشه: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Käynnistysohjelma"</string>
     <string name="home" msgid="5921706419368316758">"Aloitusruutu"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core -sovellukset"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Aloitusruutu"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core -sovellukset"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Valitse taustakuva"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Aseta taustakuva"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Taustakuvat"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Kansio on suljettu"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Kansion nimeksi vaihdettiin <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Kansio: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -22,7 +22,6 @@
     <string name="application_name" msgid="8424725141379931883">Accueil du Fairphone 1</string>
     <string name="home" msgid="5921706419368316758">"Accueil"</string>
     <string name="uid_name" msgid="3371120195364560632">"Applications de base Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Sélectionnez un fond d\'écran dans"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Sélectionner"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Fonds d\'écran"</string>
@@ -107,10 +106,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Dossier fermé"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Nouveau nom du dossier : <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Dossier : <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 
     <!-- Fairphone -->
     <!-- Your Apps -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -19,7 +19,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="application_name" msgid="8424725141379931883">"Système d’exploitation (OS) du Fairphone"</string>
+    <string name="application_name" msgid="8424725141379931883">Accueil du Fairphone 1</string>
     <string name="home" msgid="5921706419368316758">"Accueil"</string>
     <string name="uid_name" msgid="3371120195364560632">"Applications de base Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"लॉन्चर"</string>
     <string name="home" msgid="5921706419368316758">"मुखपृष्ठ"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android मुख्य एप्लिकेशन"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"मुखपृष्ठ"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android मुख्य एप्लिकेशन"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"वॉलपेपर यहां से चुनें:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"वॉलपेपर सेट करें"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"वॉलपेपर"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"फ़ोल्डर बंद किया गया"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"फ़ोल्डर का नाम बदलकर <xliff:g id="NAME">%1$s</xliff:g> किया गया"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"फ़ोल्डर: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Pokretač"</string>
     <string name="home" msgid="5921706419368316758">"Početna"</string>
     <string name="uid_name" msgid="3371120195364560632">"Matične aplikacije za Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Početna"</string>
     <string name="uid_name" msgid="3371120195364560632">"Matične aplikacije za Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Odabir pozadinske slike iz"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Postavi pozadinsku sliku"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Pozadinske slike"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mapa zatvorena"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mapa je preimenovana u <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mapa: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Indító"</string>
     <string name="home" msgid="5921706419368316758">"Főoldal"</string>
     <string name="uid_name" msgid="3371120195364560632">"Alap Android-alkalmazások"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Főoldal"</string>
     <string name="uid_name" msgid="3371120195364560632">"Alap Android-alkalmazások"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Válasszon tapétát innen:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Háttérkép kiválasztása"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Háttérképek"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mappa lezárva"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mappa új neve: <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mappa: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Peluncur"</string>
     <string name="home" msgid="5921706419368316758">"Beranda"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Beranda"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Pilih wallpaper dari"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Setel wallpaper"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Wallpaper"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Folder ditutup"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Folder diubah namanya menjadi <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folder: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Avvio applicazioni"</string>
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Scegli sfondo da"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Imposta sfondo"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Sfondi"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Cartella chiusa"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Cartella rinominata in <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Cartella: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"מפעיל"</string>
     <string name="home" msgid="5921706419368316758">"בית"</string>
     <string name="uid_name" msgid="3371120195364560632">"יישומי ליבה של Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"בית"</string>
     <string name="uid_name" msgid="3371120195364560632">"יישומי ליבה של Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"בחר טפט מ-"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"הגדר טפט"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"טפטים"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"התיקייה נסגרה"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"שם התיקיה שונה ל-<xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"תיקיה: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"ランチャー"</string>
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"壁紙の選択"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"壁紙に設定"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"壁紙"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"フォルダは閉じています"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"フォルダの名前を「<xliff:g id="NAME">%1$s</xliff:g>」に変更しました"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"フォルダ: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"홈"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core 애플리케이션"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"홈"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core 애플리케이션"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"배경화면 선택"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"배경화면 설정"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"배경화면"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"폴더 닫음"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"폴더 이름 변경: <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"폴더: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Paleidimo priemonė"</string>
     <string name="home" msgid="5921706419368316758">"Pagrindinis"</string>
     <string name="uid_name" msgid="3371120195364560632">"Pagrindinės „Android“ programos"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Pagrindinis"</string>
     <string name="uid_name" msgid="3371120195364560632">"Pagrindinės „Android“ programos"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Pasirinkti darbalaukio foną iš"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Nustatyti darbalaukio foną"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Darbalaukio fonai"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Aplankas uždarytas"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Aplankas pervardytas kaip „<xliff:g id="NAME">%1$s</xliff:g>“"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Aplankas: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Palaidējs"</string>
     <string name="home" msgid="5921706419368316758">"Sākums"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android kodola lietojumprogrammas"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Sākums"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android kodola lietojumprogrammas"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Fona tapetes izvēle:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Iestatīt tapeti"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tapetes"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mape aizvērta"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mape pārdēvēta par: <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mape: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Pelancar"</string>
     <string name="home" msgid="5921706419368316758">"Laman Utama"</string>
     <string name="uid_name" msgid="3371120195364560632">"Apl Teras Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Laman Utama"</string>
     <string name="uid_name" msgid="3371120195364560632">"Apl Teras Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Pilih kertas dinding dari"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Tetapkan kertas dinding"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Kertas dinding"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Folder ditutup"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Folder dinamakan semula kepada <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folder: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Utskytingsrampe"</string>
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kjerneapplikasjoner"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kjerneapplikasjoner"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Velg bakgrunnsbilde fra"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Velg som bakgrunnsbilde"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Bakgrunner"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mappen ble lukket"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mappen heter nå <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mappe: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Fairphone OS"</string>
     <string name="home" msgid="5921706419368316758">"Startpagina"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kerntoepassingen"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Startpagina"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android-kerntoepassingen"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Achtergrond kiezen van"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Achtergrond instellen"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Achtergronden"</string>
@@ -106,10 +105,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Map gesloten"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"De naam van de map is gewijzigd in <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Map: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
     
     <!-- Fairphone -->
     <!-- Your Apps -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Program uruchamiający"</string>
     <string name="home" msgid="5921706419368316758">"Strona główna"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplikacje główne systemu Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Strona główna"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplikacje główne systemu Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Wybierz tapetę z..."</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Ustaw tapetę"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tapety"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Folder zamknięty"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Nazwa folderu zmieniona na <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folder: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Página Inicial"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicações Principais do Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Página Inicial"</string>
     <string name="uid_name" msgid="3371120195364560632">"Aplicações Principais do Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Escolher imagem de fundo de"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Definir imagem de fundo"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Imagens de fundo"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Pasta fechada"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Nome de pasta alterado para <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Pasta: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Início"</string>
     <string name="uid_name" msgid="3371120195364560632">"Principais aplicativos do Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Selecionar plano de fundo de"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Definir plano de fundo"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Papéis de parede"</string>
@@ -106,10 +105,6 @@
     <string name="folder_closed" msgid="3130534551370511932">"Pasta fechada"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Pasta renomeada para <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Pasta: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
     
     <!-- Fairphone -->
     

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Fairphone OS"</string>
     <string name="home" msgid="5921706419368316758">"Início"</string>
     <string name="uid_name" msgid="3371120195364560632">"Principais aplicativos do Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Lantschader"</string>
     <!-- no translation found for home (5921706419368316758) -->
     <skip />
     <string name="uid_name" msgid="3371120195364560632">"Applicaziuns da basa dad Android"</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -22,7 +22,6 @@
     <!-- no translation found for home (5921706419368316758) -->
     <skip />
     <string name="uid_name" msgid="3371120195364560632">"Applicaziuns da basa dad Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <!-- no translation found for chooser_wallpaper (6063168087625352235) -->
     <skip />
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Definir in fund davos"</string>
@@ -167,8 +166,4 @@
     <skip />
     <!-- no translation found for folder_name_format (3051680259794759037) -->
     <skip />
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Lansator"</string>
     <string name="home" msgid="5921706419368316758">"Ecran de pornire"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Ecran de pornire"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Alegeţi imaginea de fundal din"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Setaţi imaginea de fundal"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Imagini de fundal"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Dosar închis"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Dosar redenumit <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Dosar: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Главный экран"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основные приложения"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Главный экран"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основные приложения"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Установка обоев"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Установить обои"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Обои"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Папка закрыта"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Папка переименована в \"<xliff:g id="NAME">%1$s</xliff:g>\""</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Папка: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Spúšťač"</string>
     <string name="home" msgid="5921706419368316758">"Plocha"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Plocha"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Vybrať tapetu z"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Nastaviť tapetu"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Tapety"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Priečinok je uzavretý"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Priečinok bol premenovaný na <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Priečinok: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Zaganjalnik"</string>
     <string name="home" msgid="5921706419368316758">"Začetna stran"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Začetna stran"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Izberite sliko za ozadje"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Nastavi sliko za ozadje"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Slike za ozadje"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mapa je zaprta"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mapa je preimenovana v <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mapa: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Покретач"</string>
     <string name="home" msgid="5921706419368316758">"Почетна"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основне Android апликације"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Почетна"</string>
     <string name="uid_name" msgid="3371120195364560632">"Основне Android апликације"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Избор позадине из"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Подеси позадину"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Позадине"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Директоријум је затворен"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Директоријум је преименован у <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Директоријум: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Startbild"</string>
     <string name="home" msgid="5921706419368316758">"Startsida"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Startsida"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Välj bakgrund från"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Ange bakgrund"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Bakgrundsbilder"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Mappen är stängd"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Mappen har bytt namn till <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Mapp: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Kizinduzi"</string>
     <string name="home" msgid="5921706419368316758">"Nyumbani"</string>
     <string name="uid_name" msgid="3371120195364560632">"Programu Kuu za Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Nyumbani"</string>
     <string name="uid_name" msgid="3371120195364560632">"Programu Kuu za Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Chagua mandhari kutoka"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Weka mandhari"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Mandhari"</string>
@@ -108,8 +107,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Folda imefungwa"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Folda imebadilishwa jina hadi <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folda: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"ตัวเรียกใช้งาน"</string>
     <string name="home" msgid="5921706419368316758">"หน้าแรก"</string>
     <string name="uid_name" msgid="3371120195364560632">"แอปหลัก Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"หน้าแรก"</string>
     <string name="uid_name" msgid="3371120195364560632">"แอปหลัก Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"เลือกวอลเปเปอร์จาก"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"ตั้งค่าวอลเปเปอร์"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"วอลเปเปอร์"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"โฟลเดอร์ปิดอยู่"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"เปลี่ยนชื่อโฟลเดอร์เป็น <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"โฟลเดอร์: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Home"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Pumili ng wallpaper mula sa"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Itakda ang wallpaper"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Mga Wallpaper"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Nakasara ang folder"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Binago ang pangalan ng folder patungong <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Folder: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Launcher"</string>
     <string name="home" msgid="5921706419368316758">"Ana Ekran"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Ana Ekran"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Duvar kağıdı seçin:"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Duvar kağıdını ayarla"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Duvar Kağıtları"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Klasör kapatıldı"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Klasörün adı <xliff:g id="NAME">%1$s</xliff:g> olarak değiştirildi"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Klasör: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Пан. запуску"</string>
     <string name="home" msgid="5921706419368316758">"Домашня сторінка"</string>
     <string name="uid_name" msgid="3371120195364560632">"Служби Android Core"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Домашня сторінка"</string>
     <string name="uid_name" msgid="3371120195364560632">"Служби Android Core"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Вибрати фоновий малюнок з"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Устан. фон. мал."</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Фонові мал."</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Папку закрито"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Папку перейменовано на <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Папка: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Trình khởi chạy"</string>
     <string name="home" msgid="5921706419368316758">"Trang chủ"</string>
     <string name="uid_name" msgid="3371120195364560632">"Ứng dụng Lõi Android"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Trang chủ"</string>
     <string name="uid_name" msgid="3371120195364560632">"Ứng dụng Lõi Android"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Chọn hình nền từ"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Đặt hình nền"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Hình nền"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Đã đóng thư mục"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Đã đổi tên thư mục thành <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Thư mục: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"启动器"</string>
     <string name="home" msgid="5921706419368316758">"主屏幕"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android 核心应用"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"主屏幕"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android 核心应用"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"选择壁纸来源"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"设置壁纸"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"壁纸"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"文件夹已关闭"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"已将文件夹重命名为“<xliff:g id="NAME">%1$s</xliff:g>”"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"文件夹：<xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"啟動器"</string>
     <string name="home" msgid="5921706419368316758">"住家"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android 核心應用程式"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"住家"</string>
     <string name="uid_name" msgid="3371120195364560632">"Android 核心應用程式"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"選擇桌布來源"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"設定桌布"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"桌布"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"已關閉資料夾"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"已將資料夾重新命名為 <xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"資料夾：<xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -19,7 +19,6 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="application_name" msgid="8424725141379931883">"Isiqalisi"</string>
     <string name="home" msgid="5921706419368316758">"Ikhaya"</string>
     <string name="uid_name" msgid="3371120195364560632">"I-Android Core Apps"</string>
     <string name="folder_name" msgid="8551881338202938211"></string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -21,7 +21,6 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="home" msgid="5921706419368316758">"Ikhaya"</string>
     <string name="uid_name" msgid="3371120195364560632">"I-Android Core Apps"</string>
-    <string name="folder_name" msgid="8551881338202938211"></string>
     <string name="chooser_wallpaper" msgid="6063168087625352235">"Khetha iphephalodonga kwi"</string>
     <string name="wallpaper_instructions" msgid="4215640646180727542">"Hlela iphephadonga"</string>
     <string name="pick_wallpaper" msgid="5630222540525626723">"Amaphephadonga"</string>
@@ -106,8 +105,4 @@
     <string name="folder_closed" msgid="3130534551370511932">"Ifolda ivaliwe"</string>
     <string name="folder_renamed" msgid="7951233572858053642">"Ifolda iqanjwe kabusha ngo-<xliff:g id="NAME">%1$s</xliff:g>"</string>
     <string name="folder_name_format" msgid="3051680259794759037">"Ifolda: <xliff:g id="NAME">%1$s</xliff:g>"</string>
-    <string name="custom_workspace_cling_title_1" msgid="1433009175359948587"></string>
-    <string name="custom_workspace_cling_description_1" msgid="6875529190849858047"></string>
-    <string name="custom_workspace_cling_title_2" msgid="5516006164661020362"></string>
-    <string name="custom_workspace_cling_description_2" msgid="2758258454975288377"></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <!-- General -->
     <skip />
     <!-- Application name -->
-    <string name="application_name">Fairphone OS</string>
+    <string name="application_name">Fairphone 1 Launcher</string>
     <!-- AppSwitcher Widget  name -->
     <string name="app_switcher_name">Your apps</string>
     <!-- AppSwitcher Widget  name -->


### PR DESCRIPTION
Coming from: #5 

Removing "Fairphone OS" name, as the launcher is just a third-party launcher now.

There are a lot of languages, BTW. Should we just remove the localized string of those we don't know, so they default to "Fairphone First Edition Launcher", in English?